### PR TITLE
fix: Resolve SharedArrayBuffer compatibility in processData

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "othent",
-  "version": "1.0.641",
+  "version": "1.0.644",
   "description": "Merging Web2 to Web3 user logins with a familiar and simple interface",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -126,7 +126,7 @@ export async function Othent(params: useOthentProps): Promise<useOthentReturnPro
                 dataBuffer = Buffer.from(data, 'utf8');
             } else if (Buffer.isBuffer(data)) {
                 dataBuffer = data;
-            } else if (data instanceof ArrayBuffer || data instanceof SharedArrayBuffer) {
+            } else if (data instanceof ArrayBuffer || (typeof SharedArrayBuffer !== 'undefined' && data instanceof SharedArrayBuffer)) {
                 dataBuffer = Buffer.from(data);
             } else if (data instanceof Uint8Array) {
                 dataBuffer = Buffer.from(data.buffer);


### PR DESCRIPTION
# Fix
- `SharedArrayBuffer` may be disabled by browsers.  So, check for the presence of the `SharedArrayBuffer` implementation to determine if the data is an instance of `SharedArrayBuffer`.




